### PR TITLE
Fixed  Error "No such keg: /usr/local/Cellar/openssl"

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -168,9 +168,10 @@ brew_setup_openssl() {
     # a version good enough. Time for brew!   
  
     # is the brew openssl installed? if not, install
+    brew_openssl_version=$(brew list --versions | grep openssl | awk 'NR==1{print $2}')
     brew_openssl_path=$(brew list openssl | grep -e '/openssl$')
     # warn "brew openssl path = $brew_openssl_path"
-    if [[ -z $brew_openssl_path ]]; then
+    if [[ -z $brew_openssl_path || -n $brew_openssl_version ]]; then
         warn "Installing openssl..."
         brew_write install openssl
         brew_openssl_path=$(brew list openssl | grep -e '/openssl$')


### PR DESCRIPTION
cc @duylam @ledinhphuong 
The issue is `openssl` doesn't continue the installing process if the default version is not okay. When the issue is fixed, we don't need to require end users install OpenSSL through Homebrew.

Note: The error message looks like that:

```
This script may install or upgrade the following software:
  - brew
  - openssl
  - libffi
  - python and pip
  - libimobiledevice and related utilities
Okay to continue? [Y/n]y

You seem to have brew.
brew's stuff seems to be owned by khanhdo...
Trying to check if /usr/bin/openssl openssl version is okay...
Found /usr/bin/openssl version 0.9.8zh.
/usr/bin/openssl version was not okay!
Error: No such keg: /usr/local/Cellar/openssl
```